### PR TITLE
Don't allow initial attributes to affect previous()

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ When cloning on a collection, a custom `comparator` is NOT transferred over to t
 
 Defining a `modelId` is not supported.
 
+`previous` does not return initial attributes sent to a model's constructor (pending [Pull Request](https://github.com/jashkenas/backbone/pull/3388) for backbone)
+
 # Why?
 
 Grooveshark needed a extremely lightweight framework for dealing with Models/Collections. It was acceptable to cut features and cut corners

--- a/bedrock.js
+++ b/bedrock.js
@@ -297,8 +297,8 @@
     if (validAttrs === false) this.valid = false;
     if (this.defaults) attrs = _.defaults({}, attrs, this.defaults);
     if (attrs.hasOwnProperty(this.idAttribute)) this.id = attrs[this.idAttribute];
-    this._previousAttributes = {};
     this.attributes = attrs;
+    this._previousAttributes = null;
     this.changed = {};
     this.initialize.call(this, attrs, options);
   };


### PR DESCRIPTION
I'm going to let this get merged before https://github.com/jashkenas/backbone/pull/3388 because its breaking stuff for us and I added a note to the README about possibly differing from backbone.
